### PR TITLE
Add light theme and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,29 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="theme-color" content="#121826">
+    <script>
+      (function () {
+        try {
+          const storageKey = 'junat-theme';
+          const storedTheme = localStorage.getItem(storageKey);
+          const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+          const theme = storedTheme === 'light' || storedTheme === 'dark'
+            ? storedTheme
+            : prefersLight
+              ? 'light'
+              : 'dark';
+
+          document.documentElement.dataset.theme = theme;
+
+          const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+          if (metaThemeColor) {
+            metaThemeColor.setAttribute('content', theme === 'light' ? '#f8fafc' : '#121826');
+          }
+        } catch (error) {
+          console.warn('Unable to initialise theme', error);
+        }
+      })();
+    </script>
     <link rel="apple-touch-icon" href="/icons/train-180.png">
     <link rel="stylesheet" href="junat.css?v=2">
     <script src="junat.js?v=2" defer></script>
@@ -21,9 +44,15 @@
             <p class="brand-subtitle">Live commuter departures</p>
           </div>
         </div>
-        <div class="status-block">
-          <span class="status-label">Updated</span>
-          <time id="time" class="status-value" aria-live="polite"></time>
+        <div class="header-actions">
+          <div class="status-block">
+            <span class="status-label">Updated</span>
+            <time id="time" class="status-value" aria-live="polite"></time>
+          </div>
+          <button id="theme-toggle" class="theme-toggle" type="button">
+            <span class="theme-toggle__icon" aria-hidden="true">☀️</span>
+            <span class="theme-toggle__label">Switch to light theme</span>
+          </button>
         </div>
       </header>
       <main id="data" class="lines" aria-live="polite"></main>

--- a/index.html
+++ b/index.html
@@ -49,9 +49,13 @@
             <span class="status-label">Updated</span>
             <time id="time" class="status-value" aria-live="polite"></time>
           </div>
-          <button id="theme-toggle" class="theme-toggle" type="button">
+          <button
+            id="theme-toggle"
+            class="theme-toggle"
+            type="button"
+            aria-label="Switch to light theme"
+          >
             <span class="theme-toggle__icon" aria-hidden="true">☀️</span>
-            <span class="theme-toggle__label">Switch to light theme</span>
           </button>
         </div>
       </header>

--- a/index.html
+++ b/index.html
@@ -6,29 +6,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="theme-color" content="#121826">
-    <script>
-      (function () {
-        try {
-          const storageKey = 'junat-theme';
-          const storedTheme = localStorage.getItem(storageKey);
-          const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
-          const theme = storedTheme === 'light' || storedTheme === 'dark'
-            ? storedTheme
-            : prefersLight
-              ? 'light'
-              : 'dark';
-
-          document.documentElement.dataset.theme = theme;
-
-          const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-          if (metaThemeColor) {
-            metaThemeColor.setAttribute('content', theme === 'light' ? '#f8fafc' : '#121826');
-          }
-        } catch (error) {
-          console.warn('Unable to initialise theme', error);
-        }
-      })();
-    </script>
+    <script src="theme-init.js?v=1"></script>
     <link rel="apple-touch-icon" href="/icons/train-180.png">
     <link rel="stylesheet" href="junat.css?v=2">
     <script src="junat.js?v=2" defer></script>

--- a/junat.css
+++ b/junat.css
@@ -8,6 +8,51 @@
   --accent: #38bdf8;
   --danger: #f87171;
   --font-base: "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --brand-icon-border: rgba(148, 163, 184, 0.18);
+  --brand-icon-shadow: 0 8px 20px rgba(15, 23, 42, 0.35);
+  --status-bg: rgba(148, 163, 184, 0.12);
+  --status-border: rgba(148, 163, 184, 0.16);
+  --row-border: rgba(148, 163, 184, 0.14);
+  --badge-bg: rgba(56, 189, 248, 0.18);
+  --badge-text: #e0f2fe;
+  --estimate-bg: rgba(56, 189, 248, 0.18);
+  --estimate-text: #bae6fd;
+  --track-bg: rgba(148, 163, 184, 0.18);
+  --cancelled-border: rgba(248, 113, 113, 0.35);
+  --cancelled-bg: rgba(248, 113, 113, 0.16);
+  --cancelled-chip-bg: rgba(248, 113, 113, 0.22);
+  --cancelled-chip-text: rgba(248, 209, 209, 0.9);
+  --toggle-bg: rgba(148, 163, 184, 0.12);
+  --toggle-border: rgba(148, 163, 184, 0.3);
+  --toggle-hover-border: rgba(148, 163, 184, 0.45);
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --bg-primary: #f8fafc;
+  --bg-card: rgba(255, 255, 255, 0.92);
+  --bg-row: rgba(241, 245, 249, 0.95);
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --accent: #0284c7;
+  --danger: #dc2626;
+  --brand-icon-border: rgba(148, 163, 184, 0.26);
+  --brand-icon-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  --status-bg: rgba(148, 163, 184, 0.16);
+  --status-border: rgba(148, 163, 184, 0.26);
+  --row-border: rgba(148, 163, 184, 0.24);
+  --badge-bg: rgba(2, 132, 199, 0.16);
+  --badge-text: #0f172a;
+  --estimate-bg: rgba(2, 132, 199, 0.14);
+  --estimate-text: #075985;
+  --track-bg: rgba(148, 163, 184, 0.24);
+  --cancelled-border: rgba(220, 38, 38, 0.32);
+  --cancelled-bg: rgba(254, 226, 226, 0.85);
+  --cancelled-chip-bg: rgba(248, 113, 113, 0.22);
+  --cancelled-chip-text: #7f1d1d;
+  --toggle-bg: rgba(255, 255, 255, 0.78);
+  --toggle-border: rgba(148, 163, 184, 0.5);
+  --toggle-hover-border: rgba(15, 23, 42, 0.38);
 }
 
 * {
@@ -59,9 +104,9 @@ body {
   height: 44px;
   display: block;
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--brand-icon-border);
   object-fit: cover;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.35);
+  box-shadow: var(--brand-icon-shadow);
 }
 
 .brand-title {
@@ -76,14 +121,21 @@ body {
   color: var(--text-secondary);
 }
 
+.header-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+}
+
 .status-block {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   padding: 10px 12px;
   border-radius: 12px;
-  background: rgba(148, 163, 184, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: var(--status-bg);
+  border: 1px solid var(--status-border);
   gap: 2px;
 }
 
@@ -144,7 +196,7 @@ body {
   padding: 10px 12px;
   border-radius: 12px;
   background: var(--bg-row);
-  border: 1px solid rgba(148, 163, 184, 0.14);
+  border: 1px solid var(--row-border);
 }
 
 .train-badge {
@@ -153,8 +205,8 @@ body {
   justify-content: center;
   padding: 5px 12px;
   border-radius: 999px;
-  background: rgba(56, 189, 248, 0.18);
-  color: #e0f2fe;
+  background: var(--badge-bg);
+  color: var(--badge-text);
   font-weight: 600;
   font-size: 14px;
   white-space: nowrap;
@@ -177,15 +229,15 @@ body {
 .time-cell .estimate {
   padding: 4px 8px;
   border-radius: 10px;
-  background: rgba(56, 189, 248, 0.18);
-  color: #bae6fd;
+  background: var(--estimate-bg);
+  color: var(--estimate-text);
   font-size: 13px;
 }
 
 .track-pill {
   padding: 4px 9px;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.18);
+  background: var(--track-bg);
   color: var(--text-secondary);
   font-size: 13px;
   font-weight: 500;
@@ -193,8 +245,8 @@ body {
 }
 
 .departure-row.cancelled {
-  border-color: rgba(248, 113, 113, 0.35);
-  background: rgba(248, 113, 113, 0.16);
+  border-color: var(--cancelled-border);
+  background: var(--cancelled-bg);
 }
 
 .departure-row.cancelled .time-cell {
@@ -203,8 +255,66 @@ body {
 
 .departure-row.cancelled .train-badge,
 .departure-row.cancelled .track-pill {
-  background: rgba(248, 113, 113, 0.22);
-  color: rgba(248, 209, 209, 0.9);
+  background: var(--cancelled-chip-bg);
+  color: var(--cancelled-chip-text);
+}
+
+@media (max-width: 560px) {
+  .app-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .header-actions .status-block {
+    width: 100%;
+  }
+
+  .header-actions .theme-toggle {
+    align-self: flex-end;
+  }
+}
+
+.theme-toggle {
+  appearance: none;
+  border: 1px solid var(--toggle-border);
+  background: var(--toggle-bg);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-family: var(--font-base);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--toggle-hover-border);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle__icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.theme-toggle__label {
+  white-space: nowrap;
 }
 
 .empty-state {

--- a/junat.css
+++ b/junat.css
@@ -279,22 +279,21 @@ body {
   }
 }
 
+
 .theme-toggle {
   appearance: none;
   border: 1px solid var(--toggle-border);
   background: var(--toggle-bg);
   color: var(--text-secondary);
-  border-radius: 999px;
-  padding: 8px 14px;
-  font-family: var(--font-base);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  padding: 0;
 }
 
 .theme-toggle:hover,
@@ -309,12 +308,8 @@ body {
 }
 
 .theme-toggle__icon {
-  font-size: 16px;
+  font-size: 18px;
   line-height: 1;
-}
-
-.theme-toggle__label {
-  white-space: nowrap;
 }
 
 .empty-state {

--- a/junat.js
+++ b/junat.js
@@ -208,11 +208,6 @@ function updateThemeToggle(theme) {
 
   toggle.setAttribute('aria-label', label);
 
-  const labelElement = toggle.querySelector('.theme-toggle__label');
-  if (labelElement) {
-    labelElement.textContent = label;
-  }
-
   const iconElement = toggle.querySelector('.theme-toggle__icon');
   if (iconElement) {
     iconElement.textContent = nextTheme === 'light' ? '☀️' : '🌙';

--- a/junat.js
+++ b/junat.js
@@ -1,4 +1,9 @@
 const REFRESH_INTERVAL_MS = 30000;
+const THEME_STORAGE_KEY = 'junat-theme';
+const THEME_COLORS = {
+  dark: '#121826',
+  light: '#f8fafc'
+};
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: '2-digit',
@@ -161,4 +166,84 @@ function renderDeparture(train) {
   `;
 }
 
+function getPreferredTheme() {
+  try {
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      return storedTheme;
+    }
+  } catch (error) {
+    console.warn('Unable to read stored theme', error);
+  }
+
+  const datasetTheme = document.documentElement.dataset.theme;
+  if (datasetTheme === 'light' || datasetTheme === 'dark') {
+    return datasetTheme;
+  }
+
+  const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+  return prefersLight ? 'light' : 'dark';
+}
+
+function applyTheme(theme) {
+  const normalizedTheme = theme === 'light' ? 'light' : 'dark';
+  document.documentElement.dataset.theme = normalizedTheme;
+
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute('content', THEME_COLORS[normalizedTheme]);
+  }
+
+  updateThemeToggle(normalizedTheme);
+}
+
+function updateThemeToggle(theme) {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) {
+    return;
+  }
+
+  const nextTheme = theme === 'dark' ? 'light' : 'dark';
+  const label = `Switch to ${nextTheme} theme`;
+
+  toggle.setAttribute('aria-label', label);
+
+  const labelElement = toggle.querySelector('.theme-toggle__label');
+  if (labelElement) {
+    labelElement.textContent = label;
+  }
+
+  const iconElement = toggle.querySelector('.theme-toggle__icon');
+  if (iconElement) {
+    iconElement.textContent = nextTheme === 'light' ? '☀️' : '🌙';
+  }
+}
+
+function initThemeToggle() {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) {
+    return;
+  }
+
+  toggle.addEventListener('click', () => {
+    const currentTheme = document.documentElement.dataset.theme === 'light' ? 'light' : 'dark';
+    const nextTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+    applyTheme(nextTheme);
+
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    } catch (error) {
+      console.warn('Unable to persist theme selection', error);
+    }
+  });
+}
+
+function initialiseTheme() {
+  const initialTheme = getPreferredTheme();
+  applyTheme(initialTheme);
+  initThemeToggle();
+}
+
+initialiseTheme();
 updateTimeTables();

--- a/theme-init.js
+++ b/theme-init.js
@@ -1,0 +1,21 @@
+(function () {
+  try {
+    const storageKey = 'junat-theme';
+    const storedTheme = localStorage.getItem(storageKey);
+    const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+    const theme = storedTheme === 'light' || storedTheme === 'dark'
+      ? storedTheme
+      : prefersLight
+        ? 'light'
+        : 'dark';
+
+    document.documentElement.dataset.theme = theme;
+
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+    if (metaThemeColor) {
+      metaThemeColor.setAttribute('content', theme === 'light' ? '#f8fafc' : '#121826');
+    }
+  } catch (error) {
+    console.warn('Unable to initialise theme', error);
+  }
+})();


### PR DESCRIPTION
## Summary
- add early theme initialisation and a header toggle to switch between light and dark modes
- expand styling with theme-aware variables, a light color palette, and responsive header adjustments
- manage theme persistence, toggle interactions, and meta theme color updates in JavaScript

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d4f6033b3c832ca07551a5b948d8c9