### PR TITLE
Adjust header layout for status and theme controls

### DIFF
--- a/junat.css
+++ b/junat.css
@@ -123,15 +123,14 @@ body {
 
 .header-actions {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 12px;
 }
 
 .status-block {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   padding: 10px 12px;
   border-radius: 12px;
   background: var(--status-bg);
@@ -267,15 +266,15 @@ body {
 
   .header-actions {
     width: 100%;
-    align-items: stretch;
+    justify-content: space-between;
   }
 
   .header-actions .status-block {
-    width: 100%;
+    width: auto;
   }
 
   .header-actions .theme-toggle {
-    align-self: flex-end;
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the header status block and theme toggle on one row by default
- left-align the status content and ensure the theme toggle stays on the right on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d50bba8010832c8d02d63c5b865ba7