### PR TITLE
Adjust header layout for status and theme controls

### DIFF
--- a/junat.css
+++ b/junat.css
@@ -125,13 +125,13 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 12px;
+  gap: 10px;
 }
 
 .status-block {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   padding: 10px 12px;
   border-radius: 12px;
   background: var(--status-bg);
@@ -267,11 +267,11 @@ body {
 
   .header-actions {
     width: 100%;
-    align-items: stretch;
+    align-items: flex-end;
   }
 
   .header-actions .status-block {
-    width: 100%;
+    width: auto;
   }
 
   .header-actions .theme-toggle {


### PR DESCRIPTION
## Summary
- stack the header actions vertically so the updated status sits on the right of the brand while the theme toggle stays on its own row
- keep the updated layout consistent on small screens by right-aligning both status and theme controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d50bba8010832c8d02d63c5b865ba7