### PR TITLE
Nest status indicator with brand heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,16 +17,18 @@
       <header class="app-header">
         <div class="brand">
           <img class="brand-icon" src="icons/train-180.png" alt="Junat icon" />
-          <div>
-            <h1 class="brand-title">Junat</h1>
+          <div class="brand-text">
+            <div class="brand-heading">
+              <h1 class="brand-title">Junat</h1>
+              <div class="status-block">
+                <span class="status-label">Updated</span>
+                <time id="time" class="status-value" aria-live="polite"></time>
+              </div>
+            </div>
             <p class="brand-subtitle">Live commuter departures</p>
           </div>
         </div>
         <div class="header-actions">
-          <div class="status-block">
-            <span class="status-label">Updated</span>
-            <time id="time" class="status-value" aria-live="polite"></time>
-          </div>
           <button
             id="theme-toggle"
             class="theme-toggle"

--- a/junat.css
+++ b/junat.css
@@ -121,17 +121,28 @@ body {
   color: var(--text-secondary);
 }
 
-.header-actions {
+.brand-text {
   display: flex;
   flex-direction: column;
+  gap: 6px;
+}
+
+.brand-heading {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.header-actions {
+  display: flex;
   align-items: flex-end;
-  gap: 12px;
 }
 
 .status-block {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   padding: 10px 12px;
   border-radius: 12px;
   background: var(--status-bg);
@@ -259,25 +270,26 @@ body {
   color: var(--cancelled-chip-text);
 }
 
-@media (max-width: 560px) {
-  .app-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
+  @media (max-width: 560px) {
+    .app-header {
+      flex-direction: column;
+      align-items: stretch;
+    }
 
-  .header-actions {
-    width: 100%;
-    align-items: stretch;
-  }
+    .brand-heading {
+      align-items: flex-start;
+      gap: 10px;
+    }
 
-  .header-actions .status-block {
-    width: 100%;
-  }
+    .header-actions {
+      width: 100%;
+      align-items: flex-end;
+    }
 
-  .header-actions .theme-toggle {
-    align-self: flex-end;
+    .header-actions .theme-toggle {
+      align-self: flex-end;
+    }
   }
-}
 
 
 .theme-toggle {


### PR DESCRIPTION
## Summary
- place the updated status block alongside the Junat title within the brand header content
- add layout helpers so the brand heading arranges the title and status inline while keeping the theme toggle on the right
- tweak mobile styles so the new heading layout wraps cleanly on smaller screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d50bba8010832c8d02d63c5b865ba7