### PR TITLE
Align status indicator on header right

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <header class="app-header">
         <div class="brand">
           <img class="brand-icon" src="icons/train-180.png" alt="Junat icon" />
-          <div>
+          <div class="brand-text">
             <h1 class="brand-title">Junat</h1>
             <p class="brand-subtitle">Live commuter departures</p>
           </div>

--- a/junat.css
+++ b/junat.css
@@ -121,6 +121,13 @@ body {
   color: var(--text-secondary);
 }
 
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .header-actions {
   display: flex;
   flex-direction: column;
@@ -131,7 +138,7 @@ body {
 .status-block {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   padding: 10px 12px;
   border-radius: 12px;
   background: var(--status-bg);
@@ -265,17 +272,14 @@ body {
     align-items: stretch;
   }
 
+  .brand {
+    align-items: flex-start;
+    gap: 10px;
+  }
+
   .header-actions {
     width: 100%;
-    align-items: stretch;
-  }
-
-  .header-actions .status-block {
-    width: 100%;
-  }
-
-  .header-actions .theme-toggle {
-    align-self: flex-end;
+    align-items: flex-end;
   }
 }
 


### PR DESCRIPTION
## Summary
- relocate the updated status block into the header actions so the Junat title and subtitle stay grouped on the left
- stack header actions vertically so the status stays on the right above the standalone theme toggle, including mobile alignment tweaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d50bba8010832c8d02d63c5b865ba7